### PR TITLE
Optionally, and by default, attempt json decode of all lookups

### DIFF
--- a/lib/hiera/backend/consul_backend.rb
+++ b/lib/hiera/backend/consul_backend.rb
@@ -147,7 +147,15 @@ class Hiera
           end
 
         end
-        answer
+        if @config[:no_json_decode]
+          answer
+        else
+          begin
+            JSON.parse(answer)
+          rescue
+            answer
+          end
+        end
       end
 
       def parse_result(res)


### PR DESCRIPTION
Without this change, ordinary hiera lookups from consul always yield a string.
This is surprising, as structured data is returned from the yaml backend.

So, new default will always attempt to decode JSON to a structured result.
If the old behaviour is required, set :no_json_decode = true
