### PR TITLE
Add some failure handling options, skip lookups when consul not present by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ The following parameters are also valid and available:
       :host: 127.0.0.1
       :port: 8500
       :protocol: 1
+      :failure: consistent
+      :ignore_absent: true
       :use_ssl: false
       :ssl_verify: false
       :ssl_cert: /path/to/cert


### PR DESCRIPTION
Not sure if this is useful to you at all but since I'm using some of your code as building blocks I thought it is only fair to offer back my changes/additions...

To avoid complexity in initially provisioning (for now) I added the option of allowing lookups to consul to be skipped if it appears to not be installed, sort of a "disable on first-run" flag.

Additionally, there is an option to skip all lookups when consul can't be reached at initialisation time (any failure during the run still trigger an error for consistency). Not sure how I feel about this option long term so it is off for now.

To get the old behaviour back set "ignore_absent: false" in hiera.yaml.
